### PR TITLE
Added support for scraping multiple urls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,4 +25,7 @@ jobs:
     - name: Run tests
       run: |
         pytest
+        ruff check ./
+        ruff format --check
+        mypy ./webpage_content_scraper --disable-error-code=import-untyped
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Webpage Content Scraper
 
-[![PyPI](https://img.shields.io/pypi/v/python-webpage-content-scraper.svg)](https://pypi.org/project/python-webpage-content-scraper/)
+[![PyPI](https://img.shields.io/pypi/v/webpage-content-scraper.svg)](https://pypi.org/project/python-webpage-content-scraper/)
 [![Tests](https://github.com/ryan-blunden/python-webpage-content-scraper/actions/workflows/test.yml/badge.svg)](https://github.com/ryan-blunden/python-webpage-content-scraper/actions/workflows/test.yml)
 [![Changelog](https://img.shields.io/github/v/release/ryan-blunden/python-webpage-content-scraper?include_prereleases&label=changelog)](https://github.com/ryan-blunden/python-webpage-content-scraper/releases)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/ryan-blunden/python-webpage-content-scraper/blob/main/LICENSE)
@@ -22,12 +22,12 @@ playwright install firefox
 
 ## Usage
 
-Simply supply a URL and optionally, a format and timeout.
+Simply supply a list of pages and optionally, a format and timeout.
 
 ```python
 from webpage_content_scraper import fetch_page_content, Formats
 
-url = 'https://microsoft.github.io/autogen/blog/2023/10/18/RetrieveChat/'
+pages = ['https://microsoft.github.io/autogen/blog/2023/10/18/RetrieveChat/']
 
 html_content = fetch_page_content(url)
 markdown_content = fetch_page_content(url, Formats.MARKDOWN)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "webpage-content-scraper"
-version = "0.1"
+version = "0.2"
 description = "Scrape only the content from a webpage using Firefox's reader view."
 readme = "README.md"
 requires-python = ">=3.8"
@@ -25,6 +25,10 @@ Changelog = "https://github.com/ryan-blunden/python-webpage-content-scraper/rele
 Issues = "https://github.com/ryan-blunden/python-webpage-content-scraper/issues"
 CI = "https://github.com/ryan-blunden/python-webpage-content-scraper/actions"
 
-
 [project.optional-dependencies]
-test = ["pytest", "pytest-mock", "ruff"]
+dev = ["symbex"]
+test = ["pytest", "pytest-mock", "ruff", "mypy"]
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings.
+quote-style = "single"

--- a/webpage_content_scraper/__init__.py
+++ b/webpage_content_scraper/__init__.py
@@ -1,48 +1,59 @@
-import time
+from typing import List, Union
 
-from bs4 import BeautifulSoup
-from playwright.sync_api import sync_playwright
+from bs4 import BeautifulSoup, NavigableString, Tag
+from playwright.sync_api import sync_playwright, TimeoutError
 from markdownify import MarkdownConverter
 
 
 class Formats:
-    MARKDOWN = "markdown"
-    HTML = "html"
+    MARKDOWN = 'markdown'
+    HTML = 'html'
 
 
-def _get_reader_content(html):
-    soup = BeautifulSoup(html, "html.parser")
-    reader_content = soup.find(class_="moz-reader-content")
+def _get_reader_content(html: str) -> Union[Tag, NavigableString]:
+    soup = BeautifulSoup(html, 'html.parser')
+    reader_content = soup.find(class_='moz-reader-content')
 
-    if reader_content and reader_content.find():
-        return reader_content
-
-    return None
+    return reader_content if reader_content and reader_content.contents else None
 
 
-def fetch_page_content(url, format=Formats.HTML, timeout=30):
+def fetch_page_content(
+    urls: List[str], format: str = Formats.HTML, timeout: int = 10
+) -> List[Union[str, None]]:
+    if not isinstance(urls, list) or not all(isinstance(url, str) for url in urls):
+        raise ValueError('urls must be a list of strings')
+
+    pages_content: List[Union[str, None]] = []
+
     with sync_playwright() as p:
         browser = p.firefox.launch()
         page = browser.new_page()
-        page.goto(f"about:reader?url={url}")
 
-        start_time = time.time()
-        reader_content = None
+        for url in urls:
+            try:
+                page.goto(f'about:reader?url={url}', timeout=timeout * 1000)
+                page.wait_for_selector('.moz-reader-content *', timeout=timeout * 1000)
 
-        while time.time() - start_time < timeout:
-            html = page.content()
-            reader_content = _get_reader_content(html)
+                html = page.content()
+                reader_content = _get_reader_content(html)
 
-            if reader_content:
-                break
+                if not reader_content:
+                    pages_content.append('')
+                    continue
 
-            time.sleep(1)
+                if format == Formats.MARKDOWN:
+                    pages_content.append(
+                        MarkdownConverter(
+                            heading_style='ATX', heading_level=2
+                        ).convert_soup(reader_content)
+                    )
+                else:
+                    pages_content.append(str(reader_content))
+            except TimeoutError:
+                pages_content.append('')
+            except Exception as e:
+                pages_content.append(f'Error: {e}')
 
         browser.close()
 
-        if format == Formats.MARKDOWN:
-            return MarkdownConverter(heading_style="ATX", heading_level=2).convert_soup(
-                reader_content
-            )
-
-        return str(reader_content)
+    return pages_content


### PR DESCRIPTION
## Updates

- Updated the `fetch_page_content` function to require a list of URLs instead of a single URL.
- Added type hints and type checking with`mypy`
- Added ruff for linting and format checking.
- Improved error handling in the `fetch_page_content` function.
- Replaced explicit timeout waiting with Playwright's `wait_for_selector`.
- Updated usage instructions in the `README.md`
- Changed default timeout to 10 seconds

## Fixes

- Fixed an issue in the `README.md` file PyPI package name was incorrect.